### PR TITLE
Optimized net code, reduced the number of byte[]'s created in memory, opting for a buffer pool instead.

### DIFF
--- a/dev/Core/IO/BufferPool.cs
+++ b/dev/Core/IO/BufferPool.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace UltimaXNA.Core.IO
+{
+    public class BufferPool
+    {
+        private static List<BufferPool> m_Pools = new List<BufferPool>();
+
+        public static List<BufferPool> Pools { get { return m_Pools; } set { m_Pools = value; } }
+
+        private string m_Name;
+
+        private int m_InitialCapacity;
+        private int m_BufferSize;
+
+        private int m_Misses;
+        private Queue<byte[]> m_FreeBuffers;
+
+        public void GetInfo(out string name, out int freeCount, out int initialCapacity, out int currentCapacity, out int bufferSize, out int misses)
+        {
+            lock (this)
+            {
+                name = m_Name;
+                freeCount = m_FreeBuffers.Count;
+                initialCapacity = m_InitialCapacity;
+                currentCapacity = m_InitialCapacity * (1 + m_Misses);
+                bufferSize = m_BufferSize;
+                misses = m_Misses;
+            }
+        }
+
+        public BufferPool(string name, int initialCapacity, int bufferSize)
+        {
+            m_Name = name;
+
+            m_InitialCapacity = initialCapacity;
+            m_BufferSize = bufferSize;
+
+            m_FreeBuffers = new Queue<byte[]>(initialCapacity);
+
+            for (int i = 0; i < initialCapacity; ++i)
+                m_FreeBuffers.Enqueue(new byte[bufferSize]);
+
+            lock (m_Pools)
+                m_Pools.Add(this);
+        }
+        
+        public byte[] AcquireBuffer()
+        {
+            lock (this)
+            {
+                if (m_FreeBuffers.Count > 0)
+                    return m_FreeBuffers.Dequeue();
+
+                ++m_Misses;
+
+                for (int i = 0; i < m_InitialCapacity; ++i)
+                    m_FreeBuffers.Enqueue(new byte[m_BufferSize]);
+
+                return m_FreeBuffers.Dequeue();
+            }
+        }
+
+        public void ReleaseBuffer(byte[] buffer)
+        {
+            if (buffer == null)
+                return;
+
+            lock (this)
+                m_FreeBuffers.Enqueue(buffer);
+        }
+
+        public void Free()
+        {
+            lock (m_Pools)
+                m_Pools.Remove(this);
+        }
+    }
+}

--- a/dev/Core/Input/InputManager.cs
+++ b/dev/Core/Input/InputManager.cs
@@ -266,7 +266,7 @@ namespace UltimaXNA.Core.Input
                 addEvent(new InputEventMouse(MouseEvent.DragEnd, e));
                 m_MouseIsDragging = false;
             }
-            else
+            else if (m_LastMouseDown != null)
             {
                 if(!DistanceBetweenPoints(m_LastMouseDown.Position, e.Position, MouseClickMaxDelta))
                 {

--- a/dev/Core/Network/Compression/HuffmanDecompression.cs
+++ b/dev/Core/Network/Compression/HuffmanDecompression.cs
@@ -302,33 +302,28 @@ namespace UltimaXNA.Core.Network.Compression
             return 1;
         }
 
-        public bool DecompressChunk(ref byte[] src, int srcSize, ref byte[] dest, int destOffset, out int destSize)
+        public bool DecompressChunk(ref byte[] src, ref int srcOffset, int srcLength, ref byte[] dest, int destOffset, out int destLength)
         {
             Array.Clear(dest, destOffset, dest.Length - destOffset);
 
-            destSize = 0;
-
+            destLength = 0;
+            
+            int end = srcOffset + srcLength;
             int node = 0;
             int destPos = destOffset;
             int bitNum = 8;
-            int srcPos = 0;
 
-            while (srcPos < srcSize)
+            while (srcOffset < end)
             {
-                var leaf = GetBit(src[srcPos], bitNum);
+                var leaf = GetBit(src[srcOffset], bitNum);
                 var leafValue = dec_tree[node, leaf];
 
                 // all numbers below 1 (0..-256) are codewords
                 // if the halt codeword has been found, skip this byte
                 if (leafValue == -256)
                 {
-                    srcPos++;
-                    byte[] newsource = new byte[srcSize - srcPos];
-
-                    Array.Copy(src, srcPos, newsource, 0, srcSize - srcPos);
-
-                    src = newsource;
-                    destSize = destPos - destOffset;
+                    srcOffset++;
+                    destLength = destPos - destOffset;
 
                     return true;
                 }
@@ -345,18 +340,18 @@ namespace UltimaXNA.Core.Network.Compression
                 if (bitNum < 1)
                 {
                     bitNum = 8;
-                    srcPos++;
+                    srcOffset++;
                 }
 
                 // check to see if the current codeword has no end
                 // if not, make it an incomplete byte
-                if (srcPos == srcSize)
+                if (srcOffset == srcLength)
                 {
                     return false;
                 }
             }
 
-            destSize = destPos - destOffset;
+            destLength = destPos - destOffset;
 
             return false;
         }

--- a/dev/Core/Network/NetworkClient.cs
+++ b/dev/Core/Network/NetworkClient.cs
@@ -16,6 +16,7 @@ using System.Net.Sockets;
 using System.Reflection;
 using UltimaXNA.Core.Diagnostics;
 using UltimaXNA.Core.Diagnostics.Tracing;
+using UltimaXNA.Core.IO;
 using UltimaXNA.Core.Network.Compression;
 #endregion
 
@@ -27,7 +28,10 @@ namespace UltimaXNA.Core.Network
         private readonly HuffmanDecompression m_Decompression;
         private readonly List<PacketHandler>[] m_TypedHandlers;
         private readonly List<PacketHandler>[][] m_ExtendedTypedHandlers;
+        private readonly BufferPool m_BufferPool = new BufferPool("Network Client - Buffer Pool", 8, 0x10000);
         private readonly object m_SyncRoot = new object();
+        private readonly PacketChunk m_IncompleteDecompressionPacket;
+        private readonly PacketChunk m_IncompletePacket;
 
         private Queue<QueuedPacket> m_Queue = new Queue<QueuedPacket>();
         private Queue<QueuedPacket> m_WorkingQueue = new Queue<QueuedPacket>();
@@ -38,13 +42,6 @@ namespace UltimaXNA.Core.Network
 
         private bool m_IsDecompressionEnabled;
         private bool m_IsConnected;
-        private bool m_AppendNextMessage;
-
-        private byte[] m_DecompressionBuffer;
-        private byte[] m_ReceiveBuffer;
-        private byte[] m_AppendData;
-
-        private int m_ReceiveBufferPosition;
         #endregion
 
         public int ClientAddress
@@ -89,6 +86,9 @@ namespace UltimaXNA.Core.Network
         {
             m_Decompression = new HuffmanDecompression();
             m_IsDecompressionEnabled = false;
+
+            m_IncompletePacket = new PacketChunk(m_BufferPool.AcquireBuffer());
+            m_IncompleteDecompressionPacket = new PacketChunk(m_BufferPool.AcquireBuffer());
 
             m_TypedHandlers = new List<PacketHandler>[0x100];
             m_ExtendedTypedHandlers = new List<PacketHandler>[0x100][];
@@ -207,11 +207,9 @@ namespace UltimaXNA.Core.Network
                 m_WorkingQueue.Clear();
             }
 
-            if (m_ReceiveBuffer != null)
-                Array.Clear(m_ReceiveBuffer, 0, m_ReceiveBuffer.Length);
-            m_ReceiveBufferPosition = 0;
-            m_AppendNextMessage = false;
-
+            m_IncompletePacket.Clear();
+            m_IncompleteDecompressionPacket.Clear();
+            
             if (IsConnected)
             {
                 Disconnect();
@@ -255,7 +253,7 @@ namespace UltimaXNA.Core.Network
                 {
                     Tracer.Debug("Connected.");
 
-                    SocketState state = new SocketState(m_ServerSocket, ushort.MaxValue);
+                    SocketState state = new SocketState(m_ServerSocket, m_BufferPool.AcquireBuffer());
                     m_ServerSocket.BeginReceive(state.Buffer, 0, state.Buffer.Length, SocketFlags.None, OnReceive, state);
                 }
 
@@ -361,21 +359,26 @@ namespace UltimaXNA.Core.Network
                 {
                     byte[] buffer = state.Buffer;
 
-                    if (m_ReceiveBuffer == null)
-                    {
-                        m_ReceiveBuffer = new byte[0x10000];
-                    }
-
                     if (m_IsDecompressionEnabled)
                     {
                         DecompressBuffer(ref buffer, ref length);
                     }
 
-                    Buffer.BlockCopy(buffer, 0, m_ReceiveBuffer, m_ReceiveBufferPosition, length);
+                    if (m_IncompletePacket.Length > 0)
+                    {
+                        m_IncompletePacket.Prepend(buffer, length);
+                        m_IncompletePacket.Clear();
+                    }
 
-                    m_ReceiveBufferPosition += length;
+                    int offset = 0;
 
-                    ProcessReceiveBuffer();
+                    ProcessBuffer(buffer, ref offset, length);
+                    
+                    // Not all the data was processed, due to an incomplete packet
+                    if(offset < length)
+                    {
+                        m_IncompletePacket.Write(buffer, offset, length - offset);
+                    }
                 }
 
                 if (m_ServerSocket != null)
@@ -392,70 +395,69 @@ namespace UltimaXNA.Core.Network
 
         private void DecompressBuffer(ref byte[] buffer, ref int length)
         {
-            if (m_DecompressionBuffer == null)
+            byte[] source = m_BufferPool.AcquireBuffer();
+
+            int incompleteLength = m_IncompleteDecompressionPacket.Length;
+            int sourceLength = incompleteLength + length;
+
+            if (incompleteLength > 0)
             {
-                m_DecompressionBuffer = new byte[0x10000];
+                m_IncompleteDecompressionPacket.Prepend(source, 0);
+                m_IncompleteDecompressionPacket.Clear();
             }
 
-            byte[] data;
-
-            if (m_AppendNextMessage)
-            {
-                m_AppendNextMessage = false;
-
-                data = new byte[m_AppendData.Length + length];
-
-                Buffer.BlockCopy(m_AppendData, 0, data, 0, m_AppendData.Length);
-                Buffer.BlockCopy(buffer, 0, data, m_AppendData.Length, length);
-            }
-            else
-            {
-                data = new byte[length];
-                Buffer.BlockCopy(buffer, 0, data, 0, length);
-            }
+            Buffer.BlockCopy(buffer, 0, source, incompleteLength, length);
 
             int outSize;
+            int processedOffset = 0;
+            int sourceOffset = 0;
             int offset = 0;
 
-            while (m_Decompression.DecompressChunk(ref data, data.Length, ref m_DecompressionBuffer, offset, out outSize))
+            while (m_Decompression.DecompressChunk(ref source, ref sourceOffset, sourceLength, ref buffer, offset, out outSize))
             {
+                processedOffset = sourceOffset;
                 offset += outSize;
             }
-
-            buffer = m_DecompressionBuffer;
+                
             length = offset;
 
             // We've run out of data to parse, or the packet was incomplete. If the packet was incomplete,
             // we should save what's left for the next socket receive event.
-            if (data.Length > 0)
+            if (processedOffset >= sourceLength)
             {
-                m_AppendNextMessage = true;
-                m_AppendData = data;
+                m_BufferPool.ReleaseBuffer(source);
+                return;
             }
+
+            m_IncompleteDecompressionPacket.Write(source, processedOffset, sourceLength - processedOffset);
         }
-
-        private void ProcessReceiveBuffer()
+        
+        private void ProcessBuffer(byte[] buffer, ref int offset, int length)
         {
-            int index = 0;
+            int index = offset;
 
-            while (index < m_ReceiveBufferPosition)
+            while (index < length)
             {
                 int realLength;
                 PacketHandler packetHandler;
-                List<PacketHandler> packetHandlers = GetHandlers(m_ReceiveBuffer[index], m_ReceiveBuffer[index + 1]);
+                List<PacketHandler> packetHandlers = GetHandlers(buffer[index], buffer[index + 1]);
 
-                if (!GetPacketSizeAndHandler(packetHandlers, m_ReceiveBuffer, index, out realLength, out packetHandler))
+                // Ensure we have the proper handler for the size of this packet
+                if (!GetPacketSizeAndHandler(packetHandlers, buffer, index, out realLength, out packetHandler))
                 {
-                    Tracer.Warn("Unhandled packet with id: 0x{0:x2}, possible subid: 0x{1:x2}", m_ReceiveBuffer[0], m_ReceiveBuffer[1]);
+                    byte[] formatBuffer = m_BufferPool.AcquireBuffer();
+                    Buffer.BlockCopy(buffer, index, formatBuffer, 0, length - index);
+                    Tracer.Warn("Unhandled packet with id: 0x{0:x2}, possible subid: 0x{1:x2}{2}{3}", buffer[index], buffer[index + 1], Environment.NewLine, Utility.FormatBuffer(formatBuffer, length - index));
                     index = 0;
-                    m_ReceiveBufferPosition = 0;
                     break;
                 }
 
-                if ((m_ReceiveBufferPosition - index) >= realLength)
+                // Entire packet exist, so we can process it
+                if ((length - index) >= realLength)
                 {
+                    // TODO: Move this to a buffer pool, need to investigate max byte[].length and pool size
                     byte[] packetBuffer = new byte[realLength];
-                    Buffer.BlockCopy(m_ReceiveBuffer, index, packetBuffer, 0, realLength);
+                    Buffer.BlockCopy(buffer, index, packetBuffer, 0, realLength);
 
                     string name = packetHandler.Name;
                     AddPacket(name, packetHandler, packetBuffer, realLength);
@@ -469,12 +471,7 @@ namespace UltimaXNA.Core.Network
                 }
             }
 
-            m_ReceiveBufferPosition -= index;
-
-            if (m_ReceiveBufferPosition > 0)
-            {
-                Buffer.BlockCopy(m_ReceiveBuffer, index, m_ReceiveBuffer, 0, m_ReceiveBufferPosition);
-            }
+            offset = index;
         }
 
         private void AddPacket(string name, PacketHandler packetHandler, byte[] packetBuffer, int realLength)
@@ -595,6 +592,46 @@ namespace UltimaXNA.Core.Network
             }
 
             return packetHandlers;
+        }
+    }
+
+    public class PacketChunk
+    {
+        private readonly byte[] m_Buffer;
+        private int m_Length;
+
+        public PacketChunk(byte[] buffer)
+        {
+            m_Buffer = buffer;
+        }
+
+        public int Length
+        {
+            get { return m_Length; }
+        }
+
+        public void Write(byte[] source, int offset, int length)
+        {
+            Buffer.BlockCopy(source, offset, m_Buffer, m_Length, length);
+            
+            m_Length += length;
+        }
+
+        public void Prepend(byte[] dest, int length)
+        {
+            // Offset the intial buffer by the amount we need to prepend
+            if (length > 0)
+            {
+                Buffer.BlockCopy(dest, 0, dest, m_Length, length);
+            }
+
+            // Prepend the buffer to the destination buffer
+            Buffer.BlockCopy(m_Buffer, 0, dest, 0, m_Length);
+        }
+
+        public void Clear()
+        {
+            m_Length = 0;
         }
     }
 }

--- a/dev/Core/Network/SocketState.cs
+++ b/dev/Core/Network/SocketState.cs
@@ -36,10 +36,10 @@ namespace UltimaXNA.Core.Network
             set { m_DataLength = value; }
         }
 
-        public SocketState(Socket socket, int bufferSize)
+        public SocketState(Socket socket, byte[] buffer)
         {
             m_Socket = socket;
-            m_Buffer = new byte[bufferSize];
+            m_Buffer = buffer;
             m_DataLength = 0;
         }
     }

--- a/dev/Disposable.cs
+++ b/dev/Disposable.cs
@@ -1,0 +1,29 @@
+using System;
+using UltimaXNA.Core.Diagnostics;
+
+namespace UltimaXNA
+{
+    public static class Disposable
+    {
+        public static IDisposable Create(Action action)
+        {
+            return new ActionDisposable(action);
+        }
+
+        private class ActionDisposable : IDisposable
+        {
+            private readonly Action _action;
+
+            public ActionDisposable(Action action)
+            {
+                Guard.RequireIsNotNull(action, "action");
+                _action = action;
+            }
+
+            public void Dispose()
+            {
+                _action();
+            }
+        }
+    }
+}

--- a/dev/Ultima/World/WorldClient.cs
+++ b/dev/Ultima/World/WorldClient.cs
@@ -21,6 +21,7 @@ using UltimaXNA.Core.Resources;
 using UltimaXNA.Core.UI;
 using UltimaXNA.Ultima.Audio;
 using UltimaXNA.Ultima.Data;
+using UltimaXNA.Ultima.IO;
 using UltimaXNA.Ultima.Network.Client;
 using UltimaXNA.Ultima.Network.Server;
 using UltimaXNA.Ultima.Player;
@@ -42,6 +43,8 @@ namespace UltimaXNA.Ultima.World
         private Timer m_KeepAliveTimer;
         private INetworkClient m_Network;
         private UserInterfaceService m_UserInterface;
+
+        private readonly Version m_OldAddItemToContainerVersion = new Version("6.0.1.7");
 
         private WorldModel m_World;
 
@@ -68,8 +71,16 @@ namespace UltimaXNA.Ultima.World
             Register<MoveAcknowledgePacket>(0x22, "Move Acknowledged", 3, new TypedPacketReceiveHandler(ReceiveMoveAck));
             Register<DragEffectPacket>(0x23, "Drag Effect", 26, new TypedPacketReceiveHandler(ReceiveDragItem));
             Register<OpenContainerPacket>(0x24, "Open Container", 7, new TypedPacketReceiveHandler(ReceiveContainer));
-            Register<AddSingleItemToContainerPacket>(0x25, "Container Content Update", 20, new TypedPacketReceiveHandler(ReceiveAddSingleItemToContainer));
-            Register<AddSingleItemToContainerPacket>(0x25, "Container Content Update", 21, new TypedPacketReceiveHandler(ReceiveAddSingleItemToContainer));
+
+            if (FileManager.IsUnknownClientVersion || FileManager.Version < m_OldAddItemToContainerVersion)
+            {
+                Register<AddSingleItemToContainerPacket>(0x25, "Container Content Update", 20, new TypedPacketReceiveHandler(ReceiveAddSingleItemToContainer));
+            }
+            else
+            {
+                Register<AddSingleItemToContainerPacket>(0x25, "Container Content Update", 21, new TypedPacketReceiveHandler(ReceiveAddSingleItemToContainer));
+            }
+
             Register<LiftRejectionPacket>(0x27, "Lift Rejection", 2, new TypedPacketReceiveHandler(ReceiveRejectMoveItemRequest));
             Register<ResurrectionMenuPacket>(0x2C, "Resurect menu", 2, new TypedPacketReceiveHandler(ReceiveResurrectionMenu));
             Register<MobileAttributesPacket>(0x2D, "Mob Attributes", 17, new TypedPacketReceiveHandler(ReceiveMobileAttributes));

--- a/dev/UltimaXNA.csproj
+++ b/dev/UltimaXNA.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Core\Input\KeyboardEvent.cs" />
     <Compile Include="Core\Input\MouseButton.cs" />
     <Compile Include="Core\Input\MouseEvent.cs" />
+    <Compile Include="Core\IO\BufferPool.cs" />
     <Compile Include="Core\Resolutions.cs" />
     <Compile Include="Core\Windows\CultureHandler.cs" />
     <Compile Include="Core\Windows\WinMouseButtons.cs" />
@@ -224,6 +225,7 @@
     <Compile Include="Core\PluginManager.cs" />
     <Compile Include="Core\UI\RenderedTextList.cs" />
     <Compile Include="Core\UI\RenderedText.cs" />
+    <Compile Include="Disposable.cs" />
     <Compile Include="ServiceRegistry.cs" />
     <Compile Include="Core\Audio\AudioEffects.cs" />
     <Compile Include="Ultima\Audio\AudioService.cs" />


### PR DESCRIPTION
Fixed a null reference in InputManager.
Packet 0x25 now registered by client version.
Huffman compression performance improvements, no longer modifies buffers.
